### PR TITLE
Added container registration for Func<IRouteCache>.

### DIFF
--- a/src/Nancy.Bootstrappers.StructureMap/StructureMapNancyBootstrapper.cs
+++ b/src/Nancy.Bootstrappers.StructureMap/StructureMapNancyBootstrapper.cs
@@ -70,6 +70,11 @@
             // Adding this hear because SM doesn't use the greediest resolvable
             // constructor, just the greediest
             applicationContainer.Configure(registry => registry.For<IFileSystemReader>().Singleton().Use<DefaultFileSystemReader>());
+
+            // DefaultRouteCacheProvider doesn't have a parameterless constructor.
+            // It has a Func<IRouteCache> parameter, which StructureMap doesn't know how to handle
+            var routeCacheFactory = new Func<IRouteCache>(ObjectFactory.GetInstance<IRouteCache>);
+            applicationContainer.Configure(registry => registry.For<Func<IRouteCache>>().Use(routeCacheFactory));
         }
 
         /// <summary>


### PR DESCRIPTION
StructureMapNancyBootstrapper.GetDiagnostics(), which overrides NancyBootstrapperBase.GetDiagnostics() throws an exception because StructureMap doesn't know how to handle the Func<IRouteCache> parameter on the DefaultRouteCacheProvider constructor.  StructureMap tries to resolve Func<IRouteCache> when injecting constructor dependencies for Nancy.Diagnostics.DefaultDiagnostics.
