### PR TITLE
Refactored out the static call to ObjectFactory

### DIFF
--- a/src/Nancy.Bootstrappers.StructureMap/StructureMapNancyBootstrapper.cs
+++ b/src/Nancy.Bootstrappers.StructureMap/StructureMapNancyBootstrapper.cs
@@ -102,7 +102,7 @@
 
             // DefaultRouteCacheProvider doesn't have a parameterless constructor.
             // It has a Func<IRouteCache> parameter, which StructureMap doesn't know how to handle
-            var routeCacheFactory = new Func<IRouteCache>(ObjectFactory.GetInstance<IRouteCache>);
+            var routeCacheFactory = new Func<IRouteCache>(this.ApplicationContainer.GetInstance<IRouteCache>);
             applicationContainer.Configure(registry => registry.For<Func<IRouteCache>>().Use(routeCacheFactory));
         }
 


### PR DESCRIPTION
I found this bug when I was unable to wasn't able to view the route cache on the default Nancy diagnostics module.  It doesn't look like there's any reason making this static call would have been deliberate.  Since I haven't seen any side effects from the change other than the Route Cache feature becoming functional in the diagnostics module, I have to assume the original inclusion was an oversight.  This should be merged into the main branch and NuGet since anyone who uses the current package will break their app.  In addition to the issue with the diagnostics, it also seems like this would at the very least cause some performance degradation during route resolution.  

Note: Although, it doesn't really matter in practice for this case, StructureMap's API has an overload for the `Use` DSL method that accepts a `Func<IContext, T>` argument.  The `IContext` has a `GetInstance<T>` method, which is implemented by the `BuildSession` class.  The `BuildSession` is the same mechanism that the `Container` class uses under the hood, so the delegate with the `IContext` argument would actually be a more direct approach.  It also necessarily stays within the scope of dependencies, so you wouldn't need to have a local reference to the container like we have here in order to use it.  That version would look like `registry.For<Func<IRouteCache>>().Use((IContext context) => new Func<IRouteCache>(context.GetInstance<IRouteCache>))`, which is probably the best option.  I didn't want to make unnecessary changes to the code though, so I left it as is except for the issue that I intentionally fixed.
