### PR TITLE
This commit removes some unnecessary calls to register components, 

### DIFF
--- a/src/Nancy.Bootstrappers.StructureMap/StructureMapNancyBootstrapper.cs
+++ b/src/Nancy.Bootstrappers.StructureMap/StructureMapNancyBootstrapper.cs
@@ -43,19 +43,6 @@
         /// <returns>An <see cref="IEnumerable{T}"/> instance containing <see cref="IRequestStartup"/> instances.</returns>
         protected override IEnumerable<IRequestStartup> RegisterAndGetRequestStartupTasks(IContainer container,Type[] requestStartupTypes)
         {
-            container.Configure(
-                registry =>
-                {
-                    foreach (var requestStartupType in requestStartupTypes)
-                    {
-                        RegisterType(
-                            typeof(IRequestStartup),
-                            requestStartupType,
-                            container.Role == ContainerRole.Nested ? Lifetime.PerRequest : Lifetime.Singleton,
-                            registry);
-                    }
-                });
-
             return container.GetAllInstances<IRequestStartup>();
         }
 
@@ -94,16 +81,11 @@
         /// <param name="applicationContainer">Application container to register into</param>
         protected override void RegisterBootstrapperTypes(IContainer applicationContainer)
         {
-            applicationContainer.Configure(registry => registry.For<INancyModuleCatalog>().Singleton().Use(this));
-
-            // Adding this hear because SM doesn't use the greediest resolvable
-            // constructor, just the greediest
-            applicationContainer.Configure(registry => registry.For<IFileSystemReader>().Singleton().Use<DefaultFileSystemReader>());
-
-            // DefaultRouteCacheProvider doesn't have a parameterless constructor.
-            // It has a Func<IRouteCache> parameter, which StructureMap doesn't know how to handle
-            var routeCacheFactory = new Func<IRouteCache>(this.ApplicationContainer.GetInstance<IRouteCache>);
-            applicationContainer.Configure(registry => registry.For<Func<IRouteCache>>().Use(routeCacheFactory));
+            applicationContainer.Configure(registry =>
+            {
+                registry.For<INancyModuleCatalog>().Singleton().Use(this);
+                registry.For<IFileSystemReader>().Singleton().Use<DefaultFileSystemReader>();
+            });
         }
 
         /// <summary>
@@ -209,12 +191,7 @@
         /// <returns>A <see cref="INancyModule"/> instance</returns>
         protected override INancyModule GetModule(IContainer container, Type moduleType)
         {
-            container.Configure(registry =>
-            {
-                registry.For(typeof(INancyModule)).LifecycleIs(Lifecycles.Unique).Use(moduleType);
-            });
-
-            return container.TryGetInstance<INancyModule>();
+             return (INancyModule)container.GetInstance(moduleType);
         }
 
         public new void Dispose()


### PR DESCRIPTION
as advised by StructureMap's JDMiller. This is with the aim of minimising difficult to debug issues at load, by reducing the amount of calls made to the SM container from Nancy.

The call to configure  has been completely removed from  as it is not needed.

The  method which is called per request does not need to register the current module type on the fly, and can just return it from the container and cast it to INancyModule, as "StructureMap can happily build a concrete type even if it's not explicitly registered as long as the StructureMap container can fill the the concrete type's dependencies."
