### PR TITLE
Updated nuspec for StructureMap v4.0.1.318

### DIFF
--- a/src/Nancy.Bootstrappers.StructureMap/nancy.bootstrappers.structuremap.nuspec
+++ b/src/Nancy.Bootstrappers.StructureMap/nancy.bootstrappers.structuremap.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Nancy.Bootstrappers.StructureMap</id>
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
       <dependency id="Nancy" />
-      <dependency id="structuremap" version="3.1.6.186" />
+      <dependency id="structuremap" version="4.0.1.318" />
     </dependencies>
     <tags>Nancy StructureMap</tags>
   </metadata>


### PR DESCRIPTION
Should have been part of #39 but forgot to include it.