### PR TITLE
Changed casing of NuGet package name

### DIFF
--- a/src/Nancy.Bootstrappers.StructureMap/Nancy.BootStrappers.StructureMap.nuspec
+++ b/src/Nancy.Bootstrappers.StructureMap/Nancy.BootStrappers.StructureMap.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <id>Nancy.Bootstrappers.StructureMap</id>
+    <id>Nancy.BootStrappers.StructureMap</id>
     <version>0.6.0</version> <!-- Overridden by rake nuget task but a default is required in nuspec files -->
     <authors>Andreas Håkansson, Steven Robbins and contributors</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Reverted the NuGet package name to have a capital S or it will break when trying to publish on nuget.org

- Changed the filename of the nuspec to `Nancy.BootStrappers.StructureMap.nuspec`
- Updated the ID element, of the nuspec, to `Nancy.BootStrappers.StructureMap`

The existing packages on nuget.org uses his naming (old bug), but NuGet does not allow you to change it === it will explode if we would try and upload a package with the same name but with a different casing