### PR TITLE
Update to Nancy 2.0

### DIFF
--- a/src/Nancy.Bootstrappers.StructureMap/Nancy.Bootstrappers.StructureMap.csproj
+++ b/src/Nancy.Bootstrappers.StructureMap/Nancy.Bootstrappers.StructureMap.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseUrl>https://github.com/NancyFx/Nancy/blob/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>http://nancyfx.org</PackageProjectUrl>
     <PackageTags>Nancy;StructureMap</PackageTags>
-    <TargetFrameworks>netstandard1.6;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <Version>2.0.0-clinteastwood</Version>
   </PropertyGroup>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy.Bootstrappers.StructureMap/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

I updated the submodule and raised target framework to `netstandard2.0` match that on Nancy.